### PR TITLE
Improvement of index page design

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,15 @@ html, body {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+
+// To manage highlighting of cards from map
+.custom-marker {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.marker-highlight {
+  transform: scale(1.3);
+  box-shadow: 0 0 10px rgba(0, 150, 0, 0.5);
+  z-index: 1000;
+}

--- a/app/assets/stylesheets/pages/_gardens.scss
+++ b/app/assets/stylesheets/pages/_gardens.scss
@@ -1,0 +1,51 @@
+.garden-card {
+  border: none;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease-in-out;
+  background-color: #fff;
+
+  &:hover {
+    transform: scale(1.02);
+  }
+
+  .card-img-top {
+    height: 200px;
+    object-fit: cover;
+  }
+
+  .garden-card-title {
+    font-size: 1.1rem;
+    font-weight: bold;
+  }
+
+  .garden-card-btn {
+    margin-top: 10px;
+  }
+}
+
+.mapbox {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.map-container {
+  width: 100%;
+  height: 80vh;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.highlight {
+  border: 2px solid #198754;
+  box-shadow: 0 0 15px rgba(25, 135, 84, 0.4);
+  transition: box-shadow 0.3s ease;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,5 @@ import "@hotwired/turbo-rails"
 import "controllers"
 import "@popperjs/core"
 import "bootstrap"
+import MapHighlightController from "./controllers/map-highlight_controller"
+application.register("map-highlight", MapHighlightController)

--- a/app/javascript/controllers/map-highlight_controller.js
+++ b/app/javascript/controllers/map-highlight_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    lat: Number,
+    lng: Number
+  }
+
+  highlight() {
+    const event = new CustomEvent("highlight-marker", {
+      detail: {
+        lat: this.latValue,
+        lng: this.lngValue
+      }
+    })
+    window.dispatchEvent(event)
+  }
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -8,40 +8,46 @@ export default class extends Controller {
   }
 
   connect() {
-
     mapboxgl.accessToken = this.apiKeyValue
 
     this.map = new mapboxgl.Map({
       container: this.element,
       style: "mapbox://styles/mapbox/outdoors-v12"
     })
+
+    this.mapMarkers = [] // pour conserver la liste des markers et leurs coords
+
     this.#addMarkersToMap()
     this.#fitMapToMarkers()
+    this.#setupCardHoverEvents()
+  }
 
-    // Écouter les événements de recherche
-    document.addEventListener("map:center", (event) => {
-      this.#centerMap(event.detail.lat, event.detail.lng)
+  #addMarkersToMap() {
+    this.markersValue.forEach((markerData) => {
+      const popup = new mapboxgl.Popup().setHTML(markerData.info_window_html)
+
+      const customMarker = document.createElement("div")
+      customMarker.innerHTML = markerData.marker_html
+      customMarker.classList.add("custom-marker")
+
+      const marker = new mapboxgl.Marker(customMarker)
+        .setLngLat([markerData.lng, markerData.lat])
+        .setPopup(popup)
+        .addTo(this.map)
+
+      // On stocke le marker + DOM + coords
+      this.mapMarkers.push({
+        marker: marker,
+        element: customMarker,
+        lat: markerData.lat,
+        lng: markerData.lng
+      })
     })
   }
 
-#addMarkersToMap() {
-  this.markersValue.forEach((marker) => {
-    const popup = new mapboxgl.Popup().setHTML(marker.info_window_html)
-
-    // Custom marker avec badge prix
-    const customMarker = document.createElement("div")
-    customMarker.innerHTML = marker.marker_html
-
-    new mapboxgl.Marker(customMarker)
-      .setLngLat([marker.lng, marker.lat])
-      .setPopup(popup)
-      .addTo(this.map)
-  })
-}
-
   #fitMapToMarkers() {
     const bounds = new mapboxgl.LngLatBounds()
-    this.markersValue.forEach(marker => bounds.extend([ marker.lng, marker.lat ]))
+    this.markersValue.forEach(marker => bounds.extend([marker.lng, marker.lat]))
     this.map.fitBounds(bounds, { padding: 70, maxZoom: 15, duration: 0 })
   }
 
@@ -49,7 +55,32 @@ export default class extends Controller {
     this.map.flyTo({
       center: [lng, lat],
       zoom: 14,
-      duration: 2000
+      duration: 500
+    })
+  }
+
+  #setupCardHoverEvents() {
+    const cards = document.querySelectorAll("[data-lat][data-lng]")
+    cards.forEach((card) => {
+      card.addEventListener("mouseover", () => {
+        const lat = parseFloat(card.dataset.lat)
+        const lng = parseFloat(card.dataset.lng)
+
+        if (!isNaN(lat) && !isNaN(lng)) {
+          this.#centerMap(lat, lng)
+          this.#highlightMarker(lat, lng)
+        }
+      })
+    })
+  }
+
+  #highlightMarker(lat, lng) {
+    this.mapMarkers.forEach(({ lat: mLat, lng: mLng, element }) => {
+      if (mLat === lat && mLng === lng) {
+        element.classList.add("marker-highlight")
+      } else {
+        element.classList.remove("marker-highlight")
+      }
     })
   }
 }

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -1,32 +1,73 @@
-<div class="row">
-  <div class="col-12">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-      <h1>Tous les jardins</h1>
-        <% if params[:query].present? %>
-          <p><strong><%= @gardens.count %></strong> jardin(s) trouvé(s) pour « <%= params[:query] %> »</p>
+<div class="container mt-5">
+  <div class="row">
+    <div class="col-12">
+      <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+        <% if params[:query].present? || params[:location].present? || params[:start_date].present? || params[:end_date].present? %>
+          <div>
+            <h1>Résultats de la recherche</h1>
+            <p>
+              <strong><%= @gardens.count %></strong> jardin(s) trouvé(s)
+              <% if params[:query].present? %>
+                pour « <%= params[:query] %> »
+              <% end %>
+            </p>
+          </div>
+        <% else %>
+          <h1>Tous les jardins</h1>
         <% end %>
-      <div style="width: 300px;">
-        <div data-controller="address-autocomplete"
-            data-address-autocomplete-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>">
-        </div>
+
+        <%# <div style="width: 300px;">
+          <div data-controller="address-autocomplete"
+               data-address-autocomplete-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>
+          <%# </div>
+        </div> %>
+      </div>
+
+      <!-- TRI PAR PRIX -->
+      <div class="mb-4">
+        <%= form_with url: gardens_path, method: :get, local: true, class: "d-inline-block" do %>
+          <div class="input-group">
+            <label class="input-group-text" for="sort">Trier par</label>
+            <%= select_tag :sort,
+                  options_for_select([["Prix croissant", "price_asc"], ["Prix décroissant", "price_desc"]], selected: params[:sort]),
+                  class: "form-select",
+                  onchange: "this.form.submit();" %>
+          </div>
+          <%= hidden_field_tag :query, params[:query] %>
+          <%= hidden_field_tag :location, params[:location] %>
+          <%= hidden_field_tag :start_date, params[:start_date] %>
+          <%= hidden_field_tag :end_date, params[:end_date] %>
+        <% end %>
       </div>
     </div>
   </div>
-</div>
+
+  <!-- VERSION MOBILE DE LA CARTE -->
+  <div class="d-lg-none mb-4">
+    <div style="width: 100%; height: 300px; border-radius: 8px; overflow: hidden;"
+         data-controller="map"
+         data-map-markers-value="<%= @markers.to_json %>"
+         data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>">
+      <div id="map-mobile" class="mapbox" style="width: 100%; height: 100%;"></div>
+    </div>
+  </div>
 
   <div class="row">
     <!-- JARDINS À GAUCHE -->
-    <div class="col-lg-7">
-      <div class="row">
+    <div class="col-lg-7 order-2 order-lg-1">
+      <div class="row pe-lg-3">
         <% if @gardens.any? %>
           <% @gardens.each do |garden| %>
             <div class="col-lg-6 mb-4">
-              <div class="card h-100">
+              <div class="card garden-card h-100"
+                   data-action="mouseover->map#highlightMarker"
+                   data-lat="<%= garden.latitude %>"
+                   data-lng="<%= garden.longitude %>">
                 <% if garden.photos.attached? %>
                   <%= cl_image_tag garden.photos.first.key,
-                                  width: 400, height: 200, crop: :fill,
-                                  class: "card-img-top",
-                                  alt: garden.title %>
+                      width: 400, height: 200, crop: :fill,
+                      class: "card-img-top",
+                      alt: garden.title %>
                 <% else %>
                   <div class="bg-light d-flex align-items-center justify-content-center card-img-top" style="height: 200px;">
                     <div class="text-center text-muted">
@@ -36,14 +77,12 @@
                   </div>
                 <% end %>
                 <div class="card-body d-flex flex-column">
-                  <h5 class="card-title"><%= garden.title %></h5>
+                  <h5 class="card-title garden-card-title"><%= garden.title %></h5>
                   <p class="card-text text-muted"><%= garden.address %></p>
                   <p class="card-text"><%= truncate(garden.description, length: 100) %></p>
-                  <div class="mt-auto">
-                    <div class="d-flex justify-content-between align-items-center">
-                      <span class="h5 text-success mb-0"><%= garden.price_per_day %>€/jour</span>
-                      <%= link_to "Voir détails", garden_path(garden), class: "btn btn-outline-primary" %>
-                    </div>
+                  <div class="mt-auto d-flex justify-content-between align-items-center">
+                    <span class="h5 text-success mb-0"><%= garden.price_per_day %>€/jour</span>
+                    <%= link_to "Voir détails", garden_path(garden), class: "btn btn-primary garden-card-btn" %>
                   </div>
                 </div>
               </div>
@@ -63,14 +102,22 @@
       </div>
     </div>
 
-    <!-- CARTE À DROITE -->
-    <div class="col-lg-5">
-      <div class="sticky-top" style="top: 20px;">
-        <div style="width: 100%; height: 80vh; border-radius: 8px; overflow: hidden;"
-          data-controller="map"
-          data-map-markers-value="<%= @markers.to_json %>"
-          data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"></div>
+    <!-- CARTE À DROITE (DESKTOP UNIQUEMENT) -->
+    <div class="col-lg-5 order-1 order-lg-2 mb-4 mb-lg-0">
+      <div class="sticky-lg-top" style="top: 20px;">
+        <div class="d-none d-lg-block position-relative" style="width: 100%; height: 80vh; border-radius: 8px; overflow: hidden;"
+            data-controller="map"
+            data-map-markers-value="<%= @markers.to_json %>"
+            data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>">
+
+          <!-- Conteneur du champ de recherche -->
+          <div id="map-geocoder" class="position-absolute top-0 start-50 translate-middle-x mt-3" style="z-index: 10; width: 80%;"></div>
+
+          <!-- Carte Mapbox -->
+          <div id="map" class="mapbox" style="width: 100%; height: 100%;"></div>
+        </div>
       </div>
     </div>
+
   </div>
 </div>


### PR DESCRIPTION
J'ai mis à jour le design de la page index :

- J'ai tout mis dans un container
- J'ai repris le design des cartes utilisé dans la home page
- J'ai fais en sorte que quand on affiche tout, le h1 est "Tous les jardins" alors que quand on accède à cette page via une recherche, le h1 est "Résultats de la recherche"
- J'ai rendu la carte sticky pour que lorsque l'on a un certain nombre de résultats, elle reste en haut de la page alors qu'à gauche on fait défiler les cartes.
- Je me suis assuré que l'on ait un bon comportement responsive (la carte passe au dessus sur les tablettes ou mobiles et les fiches des jardins se mettent l'une au dessus de l'autre).
- J'ai ajouté une fonction qui permet de centrer la carte sur la localisation du jardin sur lequel on survole la carte (pas indispensable mais cool je trouve)
- J'ai ajouté une fonction de tri par prix croissant ou décroissant. On peut tout à fait mettre d'autres critères de tri ici.